### PR TITLE
Possible fix to playlist re-order bug

### DIFF
--- a/src/admin/Dashboard/Dashboard.js
+++ b/src/admin/Dashboard/Dashboard.js
@@ -5,8 +5,7 @@ import NavBar from './NavBar';
 import { Dashboard } from './styles';
 
 export default () => {
-    // Change this to 0
-    const [ selected, setSelected ] = useState(1);
+    const [ selected, setSelected ] = useState(0);
 
     const handleChange = value => {
         setSelected(value);


### PR DESCRIPTION
Potential problem: State wasn't updating asynchronously so the POST request could have not been sending the right data.
Solution: Using async/await on the state changes

OTHER:
Got rid of an unnecessary re-render in the Playlists.js file for the admin dashboard by removing the playlistCount state.