### PR TITLE
Updating different components to receive proper backend data.

### DIFF
--- a/src/admin/Dashboard/Playlists/Playlists.js
+++ b/src/admin/Dashboard/Playlists/Playlists.js
@@ -89,7 +89,6 @@ export default () => {
     const fetchPlaylists = () => {
         axios.get(`${BASE_URL}/playlists`)
         .then(res => {
-            console.log(res.data);
             setPlaylists(res.data.sort((a, b) => {
                 return a.id - b.id
             }));

--- a/src/admin/Dashboard/Releases/ReleasePreview.js
+++ b/src/admin/Dashboard/Releases/ReleasePreview.js
@@ -4,15 +4,17 @@ import { BASE_URL } from '../../../enviornment';
 import { ReleasePreview, HideOverlay, HideIcon } from '../styles';
 
 export default ({ release, selectingFeatured, handleSelect, featuredId }) => {
-    // if(featuredId){
-    //     console.log(featuredId)
-    //     console.log(release.albumId)
-    // }
+
     const [ hidden, setHidden ] = useState(release.isHidden);
 
+    /**
+     * handleHidden - handles changing the state of an album's visibility status.
+     * If the track selected is a featured track, nothing happens.
+     * To determine this, we check to see if featuredId is equal to the release id
+     */
     const handleHidden = () => {
         if(featuredId !== release.albumId || !featuredId){
-            axios.put(`${BASE_URL}/spotify/set-hidden/${release.id}`, {
+            axios.put(`${BASE_URL}/spotify/set-hidden/${release.albumId}`, {
                 isHidden: !hidden
             })
             .then(() => {
@@ -27,9 +29,9 @@ export default ({ release, selectingFeatured, handleSelect, featuredId }) => {
     return (
         <ReleasePreview>
             <div className='img-container' onClick={() => {
-                if(release.id !== featuredId){
+                if(release.albumId !== featuredId){
                     if (selectingFeatured){
-                        handleSelect(release.id);
+                        handleSelect(release.albumId);
                     } else {
                         handleHidden();
                     }
@@ -39,9 +41,9 @@ export default ({ release, selectingFeatured, handleSelect, featuredId }) => {
                 <HideOverlay display={hidden ? 1 : 0}>
                     <HideIcon/>
                 </HideOverlay>
-                    <img alt={release.name} src={release.imgUrl}/>
+                    <img alt={release.albumName} src={release.albumImgUrl}/>
             </div>
-            <p>{release.name}</p>
+            <p>{release.albumName}</p>
         </ReleasePreview>
     );
 }

--- a/src/admin/Dashboard/Releases/Releases.js
+++ b/src/admin/Dashboard/Releases/Releases.js
@@ -74,8 +74,11 @@ export default () => {
     useEffect(() => {
         axios.get(`${BASE_URL}/spotify/admin-featured`)
         .then(res => {
-            console.log(res.data);
-            setFeaturedRelease(res.data);
+            setFeaturedRelease({
+                ...res.data,
+                albumId: res.data.id,
+                albumImgUrl: res.data.imgUrl
+            });
         })
         .catch(err => {
             console.log(err);
@@ -130,9 +133,9 @@ export default () => {
                         return <ReleasePreview 
                                     key={release.albumId} 
                                     release={release} 
+                                    featuredId={featuredRelease && featuredRelease.id}
                                     selectingFeatured={selectingFeatured} 
                                     handleSelect={handleSelect}
-                                    featuredId={featuredRelease && featuredRelease.id}
                                 />
                     })}
                 </div>

--- a/src/admin/Dashboard/Releases/Releases.js
+++ b/src/admin/Dashboard/Releases/Releases.js
@@ -54,7 +54,7 @@ export default () => {
     }
 
     useEffect(() => {
-        axios.get(`${BASE_URL}/spotify/albums`)
+        axios.get(`${BASE_URL}/spotify/releases`)
         .then(res => {
             setReleases(res.data);
         })
@@ -74,7 +74,7 @@ export default () => {
     useEffect(() => {
         axios.get(`${BASE_URL}/spotify/admin-featured`)
         .then(res => {
-            console.log('Inside fetch', res.data)
+            console.log(res.data);
             setFeaturedRelease(res.data);
         })
         .catch(err => {
@@ -109,6 +109,7 @@ export default () => {
                         key={`featured-${featuredRelease.id}`} 
                         release={featuredRelease} 
                         featuredId={featuredRelease && featuredRelease.id}
+                        imgUrl={featuredRelease.imgUrl}
                     />
                 )}
             </div>
@@ -127,7 +128,7 @@ export default () => {
                 <div className='release-container'>
                     {releases && releases.map(release => {
                         return <ReleasePreview 
-                                    key={release.id} 
+                                    key={release.albumId} 
                                     release={release} 
                                     selectingFeatured={selectingFeatured} 
                                     handleSelect={handleSelect}

--- a/src/components/Home/Recent/Recent.js
+++ b/src/components/Home/Recent/Recent.js
@@ -19,22 +19,23 @@ export default () => {
     const [ featured, setFeatured ] = useState([])
     const [ latest, setLatest ] = useState([])
 
-    //  This would be a good spot to add useMemo
-    const fetchLatest = () => {
-        axios.get(`${BASE_URL}/spotify/latest`)
+    const fetchFeatured = () => {
+        axios.get(`${BASE_URL}/spotify/featured`)
         .then(res => {
-            setLatest(res.data);
+            console.log(res.data)
+            setFeatured(res.data)
         })
         .catch(err => {
             console.log(err);
         })
     }
 
-    const fetchFeatured = () => {
-        axios.get(`${BASE_URL}/spotify/featured`)
+    //  This would be a good spot to add useMemo
+    const fetchLatest = () => {
+        axios.get(`${BASE_URL}/spotify/latest`)
         .then(res => {
-            console.log(res.data)
-            setFeatured(res.data)
+            console.log(res.data);
+            setLatest(res.data);
         })
         .catch(err => {
             console.log(err);
@@ -69,10 +70,7 @@ export default () => {
                         </div>
                         <div className='recent-releases'>
                             {latest && latest.map((release, index) => {
-                                if(index > 0){
-                                    return <RecentCard release={release} key={release.albumId} index={index}/>
-                                }
-                                return null
+                                return <RecentCard release={release} key={release.albumId} index={index}/>
                             })}
                         </div>
                     </div>

--- a/src/components/Home/styles.js
+++ b/src/components/Home/styles.js
@@ -277,13 +277,13 @@ export const RecentCard = styled.div`
         font-size: 1.8rem;
     }
     @media (max-width: 1600px){
-        display: ${props => props.index === 5 && 'none'};
-    }
-    @media (max-width: 1050px){
         display: ${props => props.index === 4 && 'none'};
     }
-    @media (max-width: 800px){
+    @media (max-width: 1050px){
         display: ${props => props.index === 3 && 'none'};
+    }
+    @media (max-width: 800px){
+        display: ${props => props.index === 2 && 'none'};
     }
 `;
 

--- a/src/components/Releases/Details.js
+++ b/src/components/Releases/Details.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Details, SpotifyLogo, Button, Artist } from './styles';
+import { Details, SpotifyLogo, Button, Artist, Track, ExplicitIcon } from './styles';
+
+/**
+ * convertMsToMinute
+ * @param {int} ms - represents time in milliseconds
+ * 
+ */
+const convertMsToMinute = ms => {
+
+}
 
 export default ({ release, handleClose }) => {
     console.log(release)
@@ -38,6 +47,18 @@ export default ({ release, handleClose }) => {
             </div>
             <div className='tracks'>
                 <h2>Tracks</h2>
+                <div className='tracks-wrapper'>
+                    {release.tracks.map((track, index) => {
+                        return (
+                            <Track key={track.id} index={index}>
+                                <p>{track.trackName}</p>
+                                <div className='info'>
+                                    {track.explicit && <ExplicitIcon/>}
+                                </div>
+                            </Track>
+                        )
+                    })}
+                </div>
             </div>
             <div className='btn-container'>
                 <Button onClick={handleClose}>

--- a/src/components/Releases/Details.js
+++ b/src/components/Releases/Details.js
@@ -1,11 +1,49 @@
 import React from 'react';
-import { Details } from './styles';
+import { Details, SpotifyLogo, Button, Artist } from './styles';
 
-export default ({ release }) => {
-
+export default ({ release, handleClose }) => {
+    console.log(release)
     return (
         <Details>
-
+            <div className='img-container'>
+                <div className='logo-wrapper'>
+                    <SpotifyLogo/>
+                </div>
+                <div className='label-wrapper'>
+                    <a href='https://open.spotify.com/artist/7Md5xGlvby3sPI2NLkbYlv'>
+                        <div className='label'>
+                            <p>Roadetrix</p>
+                        </div>
+                    </a>
+                </div>
+                <img alt={release.albumName} src={release.albumImgUrl}/>
+            </div>
+            <div className='main-info'>
+                <div className='album-name'>
+                    <h3>{release.albumName}</h3>
+                    <p> - {release.tracks.length > 1 ? 'Album' : 'Single'}</p>
+                </div>
+                {release.artists.map(artist => {
+                    return(
+                        <div key={artist.artistId}>
+                            <a href={artist.artistPublicUrl}>
+                                <Artist>
+                                    <img alt={artist.artistName} src={artist.artistImgUrl}/>
+                                    <p>{artist.artistName}</p>
+                                </Artist>
+                            </a>
+                        </div>
+                    )
+                })}
+            </div>
+            <div className='btn-container'>
+                <Button onClick={handleClose}>
+                    <p>Close</p>
+                </Button>
+                <Button>
+                    <p>Listen on Spotify</p>
+                </Button>
+            </div>
         </Details>
     );
 }

--- a/src/components/Releases/Details.js
+++ b/src/components/Releases/Details.js
@@ -36,6 +36,9 @@ export default ({ release, handleClose }) => {
                     )
                 })}
             </div>
+            <div className='tracks'>
+                <h2>Tracks</h2>
+            </div>
             <div className='btn-container'>
                 <Button onClick={handleClose}>
                     <p>Close</p>

--- a/src/components/Releases/Details.js
+++ b/src/components/Releases/Details.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Details, SpotifyLogo, Button, Artist, Track, ExplicitIcon } from './styles';
+import { Details, SpotifyLogo, Button, Artist, Track, ExplicitIcon, DetailsButton } from './styles';
 
 /**
  * convertMsToMinute
@@ -7,11 +7,17 @@ import { Details, SpotifyLogo, Button, Artist, Track, ExplicitIcon } from './sty
  * 
  */
 const convertMsToMinute = ms => {
+    let minutes = Math.floor((ms / 1000 / 60 / 60) * 60);
+    let seconds = Math.floor(((ms / 1000 / 60/ 60) * 60 - minutes) * 60);
 
+    if(seconds < 10){
+        seconds = `0${seconds}`
+    }
+
+    return `${minutes}:${seconds}`
 }
 
 export default ({ release, handleClose }) => {
-    console.log(release)
     return (
         <Details>
             <div className='img-container'>
@@ -50,10 +56,11 @@ export default ({ release, handleClose }) => {
                 <div className='tracks-wrapper'>
                     {release.tracks.map((track, index) => {
                         return (
-                            <Track key={track.id} index={index}>
+                            <Track key={track.trackId} index={index}>
                                 <p>{track.trackName}</p>
                                 <div className='info'>
                                     {track.explicit && <ExplicitIcon/>}
+                                    <p>{convertMsToMinute(track.duration)}</p>
                                 </div>
                             </Track>
                         )
@@ -61,12 +68,14 @@ export default ({ release, handleClose }) => {
                 </div>
             </div>
             <div className='btn-container'>
-                <Button onClick={handleClose}>
+                <DetailsButton onClick={handleClose}>
                     <p>Close</p>
-                </Button>
-                <Button>
-                    <p>Listen on Spotify</p>
-                </Button>
+                </DetailsButton>
+                <a href={release.albumPublicUrl}>
+                    <DetailsButton color='spotify'>
+                        <p>Listen on Spotify</p>
+                    </DetailsButton>
+                </a>
             </div>
         </Details>
     );

--- a/src/components/Releases/Releases.js
+++ b/src/components/Releases/Releases.js
@@ -75,7 +75,7 @@ export default () => {
     }, [])
 
     /**
-     * Allows the user to search releases by release name
+     * Allows the user to search releases by release name, artist name, or track name
      */
     useEffect(() => {
         if(search === ''){
@@ -95,8 +95,10 @@ export default () => {
             <Backdrop className={classes.backdrop} open={!featured || !releases}>
                 <CircularProgress color="inherit" />
             </Backdrop>
-            <Backdrop className={classes.backdrop} open={currentRelease !== null} onClick={handleClose}>
-                <Details release={currentRelease}/>
+            <Backdrop className={classes.backdrop} open={currentRelease !== null}>
+                {currentRelease && (
+                    <Details release={currentRelease} handleClose={handleClose}/>
+                )}
             </Backdrop>
             <Featured>
                 {featured && (
@@ -110,7 +112,7 @@ export default () => {
                                     <Divider color='white'/>
                                     <p>{featured.albumName}</p>
                                 </div>
-                                <Button>
+                                <Button onClick={() => handleClick(featured.albumId)}>
                                     <p>View Details</p>
                                 </Button>
                             </div>

--- a/src/components/Releases/styles.js
+++ b/src/components/Releases/styles.js
@@ -226,13 +226,17 @@ export const Details = styled.div`
         }
         .tracks-wrapper{
             max-height: 300px;
-            overflow: scroll;
             width: 100%;
+            overflow-y: auto;
+            overflow-x: hidden
         }
     }
     .btn-container{
         width: 100%;
         display: flex;
+        a{
+            text-decoration: none;
+        }
     }
 `;
 
@@ -253,7 +257,7 @@ export const Artist = styled.div`
 `;
 
 export const Track = styled.div`
-    cursor: pointer;
+    cursor: default;
     width: 100%;
     background-color: ${props => props.index % 2 == 1 ? theme.colors.lightGrey : theme.colors.white};
     height: 40px;
@@ -268,6 +272,9 @@ export const Track = styled.div`
     }
     .info{
         margin-right: 15px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
     }
 `;
 
@@ -291,6 +298,28 @@ export const Button = styled.div`
         border: 1px solid ${theme.colors.lightPink};
         background-color: transparent;
         color: ${theme.colors.lightPink};
+    }
+`;
+
+export const DetailsButton = styled.div`
+    cursor: pointer;
+    margin-top: 10px;
+    width: 200px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: ${props => props.color === 'spotify' ? theme.spotify.darkGreen : theme.colors.black};
+    border: 1px solid ${props => props.color === 'spotify' ? theme.spotify.darkGreen : theme.colors.black};
+    color: ${theme.colors.white};
+    p{
+        font-family: ${theme.fonts.ubuntu};
+        font-size: 1.5rem;
+    }
+    &:hover{
+        border: 1px solid ${props => props.color === 'spotify' ? theme.spotify.darkGreen : theme.colors.black};
+        background-color: transparent;
+        color: ${props => props.color === 'spotify' ? theme.spotify.darkGreen : theme.colors.black};
     }
 `;
 

--- a/src/components/Releases/styles.js
+++ b/src/components/Releases/styles.js
@@ -186,7 +186,7 @@ export const Details = styled.div`
     }
     .main-info{
         margin: 10px 0;
-        margin-left: 10px;
+        margin-left: 30px;
         width: 100%;
         display: flex;
         flex-direction: column;
@@ -210,6 +210,23 @@ export const Details = styled.div`
         a{
             text-decoration: none;
         }
+    }
+    .tracks{
+        width: 100%;
+        margin-left: 30px;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        h2{
+            color: ${theme.colors.lightGrey};
+            font-family: ${theme.fonts.anton};
+            font-size: 2rem;
+
+        }
+    }
+    .btn-container{
+        width: 100%;
+        display: flex;
     }
 `;
 

--- a/src/components/Releases/styles.js
+++ b/src/components/Releases/styles.js
@@ -3,6 +3,7 @@ import theme from '../../theme';
 import { Search } from '@styled-icons/boxicons-regular/';
 import { Close } from '@styled-icons/evaicons-solid/';
 import { Spotify } from '@styled-icons/boxicons-logos/';
+import { Explicit } from '@styled-icons/material/';
 
 export const Releases = styled.section`
     
@@ -145,7 +146,7 @@ export const ReleaseCard = styled.div`
 `;
 
 export const Details = styled.div`
-    width: 350px;
+    width: 400px;
     background-color: ${theme.colors.white};
     display: flex;
     flex-direction: column;
@@ -213,15 +214,20 @@ export const Details = styled.div`
     }
     .tracks{
         width: 100%;
-        margin-left: 30px;
         display: flex;
         flex-direction: column;
         align-items: flex-start;
         h2{
+            margin-left: 15px;
             color: ${theme.colors.lightGrey};
             font-family: ${theme.fonts.anton};
             font-size: 2rem;
 
+        }
+        .tracks-wrapper{
+            max-height: 300px;
+            overflow: scroll;
+            width: 100%;
         }
     }
     .btn-container{
@@ -243,6 +249,25 @@ export const Artist = styled.div`
     }
     &:hover{
         color: ${theme.spotify.darkGreen} !important;
+    }
+`;
+
+export const Track = styled.div`
+    cursor: pointer;
+    width: 100%;
+    background-color: ${props => props.index % 2 == 1 ? theme.colors.lightGrey : theme.colors.white};
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    p{
+        color: ${theme.colors.lightPink};
+        font-family: ${theme.fonts.ubuntu};
+        font-size: 1.5rem;
+        margin-left: 15px;
+    }
+    .info{
+        margin-right: 15px;
     }
 `;
 
@@ -286,4 +311,9 @@ export const CloseIcon = styled(Close)`
 export const SpotifyLogo = styled(Spotify)`
     width: 80px;
     color: ${theme.spotify.darkGreen};
+`;
+
+export const ExplicitIcon = styled(Explicit)`
+    width: 20px;
+    color: ${theme.colors.lightPink};
 `;

--- a/src/components/Releases/styles.js
+++ b/src/components/Releases/styles.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import theme from '../../theme';
 import { Search } from '@styled-icons/boxicons-regular/';
+import { Close } from '@styled-icons/evaicons-solid/';
+import { Spotify } from '@styled-icons/boxicons-logos/';
 
 export const Releases = styled.section`
     
@@ -143,10 +145,88 @@ export const ReleaseCard = styled.div`
 `;
 
 export const Details = styled.div`
-    width: 400px;
-    height: 600px;
+    width: 350px;
     background-color: ${theme.colors.white};
-    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    .img-container{
+        width: 100%;
+        position: relative;
+        .logo-wrapper{
+            position: absolute;
+            right: 10px;
+            top: 10px;
+        }
+        .label-wrapper{
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            a{
+                text-decoration: none;
+            }
+            .label{
+                background-color: ${theme.spotify.darkGreen};
+                width: 90px;
+                height: 40px;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                p{
+                    font-family: ${theme.fonts.ubuntu};
+                    font-size: 1.5rem;
+                    color: ${theme.colors.white};
+                }
+            }
+        }
+        img{
+            width: 100%;
+        }
+    }
+    .main-info{
+        margin: 10px 0;
+        margin-left: 10px;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        .album-name{
+            display: flex;
+            align-items: center;
+            h3{
+                color: ${theme.colors.lightGrey};
+                font-family: ${theme.fonts.anton};
+                font-size: 3rem;
+                margin-bottom: 5px;
+                margin-right: 5px;
+            }
+        }
+        p{
+            color: ${theme.colors.lightGrey};
+            font-family: ${theme.fonts.ubuntu};
+            font-size: 1.5rem;
+        }
+        a{
+            text-decoration: none;
+        }
+    }
+`;
+
+export const Artist = styled.div`
+    margin: 3px 0;
+    display: flex;
+    align-items: center;
+    color: ${theme.colors.lightGrey};
+    img{
+        width: 50px;
+        height: 50px;
+        border-radius: 50%;
+        margin-right: 10px;
+    }
+    &:hover{
+        color: ${theme.spotify.darkGreen} !important;
+    }
 `;
 
 export const Button = styled.div`
@@ -175,4 +255,18 @@ export const Button = styled.div`
 export const SearchIcon = styled(Search)`
     width: 30px;
     color: ${theme.colors.lightGrey};
+`;
+
+export const CloseIcon = styled(Close)`
+    cursor: pointer;
+    width: 40px;
+    color: ${theme.colors.lightGrey};
+    &:hover{
+        color: ${theme.colors.lightPink};
+    }
+`;
+
+export const SpotifyLogo = styled(Spotify)`
+    width: 80px;
+    color: ${theme.spotify.darkGreen};
 `;

--- a/src/utils/fetchReleases.js
+++ b/src/utils/fetchReleases.js
@@ -74,6 +74,7 @@ export const fetchReleases = async () => {
             })
             .then(res => {
                 const tracksRes = res.data.items;
+                console.log(tracksRes)
                 for(let j=0; j<tracksRes.length; j++){
 
                     // Get data for albumId with trackId
@@ -97,7 +98,10 @@ export const fetchReleases = async () => {
                         id: tracksRes[j].id,
                         name: tracksRes[j].name,
                         externalUrl: tracksRes[j].external_urls.spotify,
-                        privateUrl: tracksRes[j].href
+                        privateUrl: tracksRes[j].href,
+                        duration: tracksRes[j].duration_ms,
+                        explicit: tracksRes[j].explicit,
+                        previewUrl: tracksRes[j].preview_url
                     })
                 }
             })


### PR DESCRIPTION
The tracks table has added 3 new properties which must be reflected on the front-end of the application.
- duration
- explicit
- preview url

All releases returned from /spotify/releases instead of only non-hidden releases.
TODO: Filter to display only releases that aren't hidden on the releases/latest page.